### PR TITLE
Feature - 12 - Add option to disable free shipping when marked product is added to cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 # Free Shipping Excluder for WooCommerce
-A WooCommerce extension that allows you to exclude specific products and categories from being counted towards the free shipping threshold. It ensures that certain products do not contribute to the total cost required for free shipping, allowing you to control shipping costs more effectively.
+A WooCommerce extension that allows you to exclude specific products and categories from being counted towards the free shipping threshold, or completely disable free shipping for the entire order when specific products are in the cart.
 
 ## Installation
 
@@ -35,6 +35,16 @@ A WooCommerce extension that allows you to exclude specific products and categor
 5. Save the changes.
 6. All products belonging to this category will now be excluded from the free shipping calculation.
 
+### Disable Free Shipping for Specific Products
+
+1. Go to 'Products' in WordPress admin.
+2. Click on any product that you wish to completely disable free shipping for.
+3. Scroll down to the 'Product Data' section.
+4. Click on the 'Shipping' tab.
+5. You will see a checkbox labeled **Disable free shipping if in cart**.
+6. Check the box to completely disable free shipping for the entire order if this product is in the cart, regardless of any thresholds.
+7. Save the changes.
+
 ### Test live and instantly with WordPress Playground
 
 [Test on WP Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/nagpai/free-shipping-excluder/refs/heads/main/_playground/github-blueprint.json)
@@ -48,6 +58,7 @@ Steps to test:
 5. Add a few other products to the cart, the flat rate shipping fee will continue to show until the value of other products except Non-free Shipping goes above 100
 6. Create a category - say `No Free Shipping`. Make sure you check the `Exclude from free shipping` checkbox.
 7. Apply the category to any product, and repeat the above tests to see if its cost is excluded from free shipping threshold calculation.
+8. Edit a product and check the **Disable free shipping if in cart** checkbox. Save the product, add it to the cart along with a cart total that exceeds USD 100 of other eligible products, and verify that free shipping is completely disabled for the entire order due to this product's presence.
 
 ## Contributing
 Contributions are welcome! Please feel free to fork and submit a pull request or open an [issue](https://github.com/nagpai/free-shipping-excluder/issues) for any improvements or bug fixes.

--- a/free-shipping-excluder.php
+++ b/free-shipping-excluder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Free Shipping Excluder for WooCommerce
  * Plugin URI: https://github.com/nagpai/free-shipping-excluder
  * Description: Exclude specific products from free shipping.
- * Version: 1.2
+ * Version: 1.3
  * Tested up to: 6.9
  * Author: Nagesh Pai
  * Author URI: https://nagpai.blog

--- a/free-shipping-excluder.php
+++ b/free-shipping-excluder.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/nagpai/free-shipping-excluder
  * Description: Exclude specific products from free shipping.
  * Version: 1.3
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * Author: Nagesh Pai
  * Author URI: https://nagpai.blog
  * Developer: Nagesh Pai

--- a/includes/admin/class-product-shipping-settings.php
+++ b/includes/admin/class-product-shipping-settings.php
@@ -58,6 +58,15 @@ class Product_Shipping_Settings {
 				'desc_tip'    => true,
 			)
 		);
+
+		woocommerce_wp_checkbox(
+			array(
+				'id'          => '_disable_free_shipping',
+				'label'       => __( 'Disable free shipping if in cart', 'free-shipping-excluder' ),
+				'description' => __( 'Completely disables free shipping for the entire order if this product is in the cart, regardless of any thresholds.', 'free-shipping-excluder' ),
+				'desc_tip'    => true,
+			)
+		);
 	}
 
 	/**
@@ -84,5 +93,8 @@ class Product_Shipping_Settings {
 
 		$exclude_from_free_shipping = isset( $_POST['_exclude_from_free_shipping'] ) ? 'yes' : 'no';
 		update_post_meta( $post_id, '_exclude_from_free_shipping', $exclude_from_free_shipping );
+
+		$disable_free_shipping = isset( $_POST['_disable_free_shipping'] ) ? 'yes' : 'no';
+		update_post_meta( $post_id, '_disable_free_shipping', $disable_free_shipping );
 	}
 }

--- a/includes/admin/class-product-shipping-settings.php
+++ b/includes/admin/class-product-shipping-settings.php
@@ -53,7 +53,7 @@ class Product_Shipping_Settings {
 		woocommerce_wp_checkbox(
 			array(
 				'id'          => '_exclude_from_free_shipping',
-				'label'       => __( 'Exclude from free shipping', 'free-shipping-excluder' ),
+				'label'       => __( 'Exclude cost from free shipping', 'free-shipping-excluder' ),
 				'description' => __( 'Exclude this product from free shipping threshold calculations. This product\'s cost will not count towards the minimum amount required for free shipping.', 'free-shipping-excluder' ),
 				'desc_tip'    => true,
 			)

--- a/includes/class-free-shipping-excluder.php
+++ b/includes/class-free-shipping-excluder.php
@@ -34,6 +34,12 @@ class Free_Shipping_Excluder {
 		$total_free_shipping_eligible_cost = 0;
 
 		foreach ( WC()->cart->get_cart() as $cart_item ) {
+
+			// Check if product disables free shipping
+			if ( $this->is_product_disabling_free_shipping( $cart_item['product_id'] ) ) {
+				return false;
+			}
+
 			// Check if product is excluded via product-level meta setting.
 			$is_excluded_by_meta = $this->is_product_excluded_by_meta( $cart_item['product_id'] );
 
@@ -86,5 +92,16 @@ class Free_Shipping_Excluder {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if the product disables free shipping for entire cart.
+	 *
+	 * @param int $product_id Product ID.
+	 * @return bool True if product disables free shipping for entire cart, false otherwise.
+	 */
+	private function is_product_disabling_free_shipping( int $product_id ): bool {
+		$disable_free_shipping = get_post_meta( $product_id, '_disable_free_shipping', true );
+		return 'yes' === $disable_free_shipping;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,21 +3,22 @@ Contributors: nagpai
 Tags: woocommerce, shipping, free shipping, product exclusion, category exclusion
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 1.2
+Stable tag: 1.3
 Requires PHP: 8.0
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Exclude specific products or entire product categories from being counted towards the free shipping threshold in WooCommerce.
+Exclude specific products or entire product categories from being counted towards the free shipping threshold, or completely disable free shipping for the entire order if a specific product is in the cart.
 
 == Description ==
 
-Free Shipping Excluder for WooCommerce gives you granular control over which products count towards your free shipping minimum amount. This is perfect for stores that sell items like gift cards, services, promotional products, or any items that shouldn't contribute to free shipping eligibility.
+Free Shipping Excluder for WooCommerce gives you granular control over how products affect your free shipping eligibility. You can exclude individual products or entire categories from counting towards your free shipping minimum amount, or completely disable free shipping for the entire order if a specific product is added to the cart. This is perfect for stores that sell items like gift cards, services, promotional products, or heavy/bulky items that shouldn't qualify for free shipping.
 
 = Features =
 
 * **Product-level exclusion** - Exclude individual products from free shipping calculations via a simple checkbox in the product shipping settings
 * **Category-level exclusion** - Exclude entire product categories, automatically applying the exclusion to all products within those categories
+* **Disable free shipping entirely** - Completely disable free shipping for the entire order if a specific product is in the cart, regardless of order total
 * **Flexible control** - Use either method or both together to match your specific business needs
 * **Seamless integration** - Works with WooCommerce's native free shipping method
 * **No configuration complexity** - Simple checkboxes, no complicated settings
@@ -25,9 +26,10 @@ Free Shipping Excluder for WooCommerce gives you granular control over which pro
 = How It Works =
 
 When a customer adds items to their cart, the plugin calculates the free shipping eligibility by:
-1. Checking each product for exclusion settings (both product-level and category-level)
-2. Summing only the eligible products' costs
-3. Comparing the total against your free shipping threshold
+1. Checking if any product in the cart has "Disable free shipping if in cart" enabled. If so, free shipping is immediately disabled for the entire order.
+2. Checking each product for exclusion settings (both product-level and category-level)
+3. Summing only the eligible products' costs
+4. Comparing the total against your free shipping threshold
 
 Excluded products can still be purchased and shipped - they just don't count towards the minimum amount needed for free shipping.
 
@@ -35,6 +37,7 @@ Excluded products can still be purchased and shipped - they just don't count tow
 
 * Exclude gift cards from free shipping calculations
 * Exclude digital products or services
+* Prevent free shipping entirely for bulky, heavy, or high-shipping-cost items
 * Exclude promotional items or samples
 * Exclude low-margin products
 * Exclude entire categories like "Accessories" or "Downloads"
@@ -52,6 +55,7 @@ You are welcome to contribute to this free and open source extension:
 == Screenshots
 1. Product level exclusion setting
 2. Category level exclusion setting
+3. Product level free shipping disable setting
 
 == Support ==
 
@@ -63,9 +67,10 @@ You are welcome to contribute to this free and open source extension:
 
 1. Upload the plugin files to the `/wp-content/plugins/free-shipping-excluder` directory, or install the plugin through the WordPress plugins screen directly
 2. Activate the plugin through the 'Plugins' screen in WordPress
-3. Go to Products > Categories to exclude entire categories, or edit individual products to exclude them
+3. Go to Products > Categories to exclude entire categories, or edit individual products to exclude them or disable free shipping entirely
 4. To exclude a product: Edit the product > Shipping tab > Check "Exclude from free shipping"
 5. To exclude a category: Products > Categories > Edit a category > Check "Exclude from free shipping"
+6. To disable free shipping entirely for a product: Edit the product > Shipping tab > Check "Disable free shipping if in cart"
 
 == Frequently Asked Questions ==
 
@@ -76,6 +81,10 @@ Edit the product in WooCommerce, go to the Shipping tab, and check the "Exclude 
 = How do I exclude an entire category? =
 
 Go to Products > Categories, edit the category you want to exclude, and check the "Exclude from free shipping" checkbox. All products in that category will be excluded.
+
+= How do I completely disable free shipping for the entire order if a specific product is in the cart? =
+
+Edit the product in WooCommerce, go to the Shipping tab, and check the "Disable free shipping if in cart" checkbox. Once checked, if a customer adds this product to their cart, the entire order will be disqualified from free shipping, regardless of the cart total or any other products present.
 
 = Can excluded products still be purchased? =
 
@@ -94,6 +103,9 @@ The plugin works with WooCommerce's native free shipping method. Compatibility w
 No, the exclusion happens behind the scenes in the cart calculation. Customers will simply see whether they qualify for free shipping based on their eligible items.
 
 == Changelog ==
+
+= 1.3 =
+* Added option to completely disable free shipping for the entire order when specific products are in the cart.
 
 = 1.2 =
 * Added virtual product exclusion feature


### PR DESCRIPTION
Fixes #12 

## Summary
This pull request introduces a new setting to individual product shipping options that allows store administrators to disable free shipping entirely for the entire order if the product is added to the cart, overriding any free shipping thresholds or rules.

## Key Changes

### Additional Product shipping setting
There is an additional checkbox introduced within the `Shipping` tab within a Product. If the checkbox is selected, free shipping is completely disabled if that product is in the cart. 

<img width="1743" height="830" alt="image" src="https://github.com/user-attachments/assets/5eb43ea6-88c1-4087-a307-a4e9aa3130fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a product-level option that, when enabled, disables free shipping for the entire order if that product is in the cart; the setting is saved reliably.

* **Documentation**
  * Updated docs and usage guide with instructions and testing steps demonstrating the new disable-free-shipping option and use cases.

* **Chores**
  * Bumped plugin version to 1.3 and updated changelog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nagpai/free-shipping-excluder/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->